### PR TITLE
changed to 12 months

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,13 +1,11 @@
 import yfinance as yf
-from datetime import date
-from dateutil.relativedelta import relativedelta
-import pandas as pd
+from   datetime import date, timedelta
 
 # Get the Facebook ticker
 fb = yf.Ticker("FB")
 
-# Gets the date 14 months from now and typecasts it to a string
-date = date.today() + relativedelta(months=+14)
+# Gets the date 12 months from now and typecasts it to a string
+date = date.today() + timedelta(weeks = 12 * 4)
 date = str(date)
 
 # Typecasts the expiration dates of all Facebook options to a list to make it easier to handle 


### PR DESCRIPTION
Made three changes:

1. Changed to 12 months from now (rather than 14). I changed my mind. Sorry.

2. No need to import panda any longer

3. Changed to use the default Python timedelta rather than relativedelta to reduce the number of imports. Leaner and simpler code. I know the new code is imprecise because 12 months != 48 weeks. However, the 12 month is an approximate timeline anyway. 48 weeks is equally fine. 😊

Thanks!