### PR TITLE
added error checking for options

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,11 @@ def main():
 	args = parser.parse_args()
 
 	ticker = yf.Ticker(args.symbol)
-	options = ticker.options
+	try:
+		options = ticker.options
+	except IndexError:
+		print("No options found.")
+		quit()
 
 	# Filter options by their expiration dates
 	eligible_options = FilterOptionsByExpDate(options, args.exp)


### PR DESCRIPTION
Some tickers have no options. In this case, the ticker library fires an error because it tries to retrieve:

```python
r['optionChain']['result'][0]['options'][0]
```
Since there are no options, the last reference ([0]) fires an exception IndexOutOfRange.

I added code to catch this exception and print out a simple message back. 